### PR TITLE
fix(workflow): reset token secret for Homebrew Tap repo steps to stan…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: serverless-dna/homebrew-tap
-          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: homebrew-tap
       
       - name: Download release artifacts

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: serverless-dna/homebrew-tap
-          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: homebrew-tap
       
       - name: Download release artifacts from GitHub
@@ -63,6 +63,8 @@ jobs:
           make update-homebrew-github VERSION="$VERSION" TAG="$TAG"
       
       - name: Commit and push formula
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd homebrew-tap
           git config user.name "GitHub Action"


### PR DESCRIPTION
Remove need for custom TAP_GITHUB token to be setup - use std GITHUB_TOKEN since repos are in the same org.